### PR TITLE
[#55] 예외처리 추가

### DIFF
--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import Header from '@/components/Header';
+
+const Login = ({ children }: { children: ReactNode }) => {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+};
+
+export default Login;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,18 +5,28 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 
-import Header from '@/components/Header';
-
 import auth from '@/app/auth';
+import { validateEmail, validatePassword } from '@/utils/validate';
 
 const Page = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<
+    'invalid' | 'unknown' | 'password' | 'email' | ''
+  >('');
   const router = useRouter();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+
+    if (!validateEmail(email)) {
+      setError('email');
+      return;
+    } else if (validatePassword(password)) {
+      setError('password');
+      return;
+    }
 
     if (isLoading) return;
 
@@ -27,26 +37,61 @@ const Page = () => {
         router.push('/');
       })
       .catch((err) => {
-        console.error(err);
+        console.error(err.message);
+        if (err.message.includes('invalid-credential')) {
+          setError('invalid');
+        } else {
+          setError('unknown');
+        }
       })
       .finally(() => {
         setIsLoading(false);
       });
   };
 
+  if (error === 'unknown') {
+    return (
+      <div className="w-2/5 mx-auto flex flex-col bg-yellow-100 p-4 mt-32 rounded-lg">
+        <h1 className="mx-auto font-bold text-red-600 text-xl">오류</h1>
+        <p className="mx-auto my-5 text-center">
+          알 수 없는 오류가 발생했습니다.
+          <br /> 다시 시도해 주세요.
+        </p>
+        <Button
+          type="button"
+          color="danger"
+          onClick={() => {
+            setError('');
+          }}
+          className="font-semibold w-3/5 mx-auto"
+        >
+          로그인 페이지로 이동하기
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <>
-      <Header />
       <h1 className="w-2/4 mx-auto text-center font-bold text-2xl mb-5 mt-32">
         로그인
       </h1>
       <div className="w-2/5 mx-auto rounded-lg bg-slate-100 p-4">
         <form className="flex flex-wrap" onSubmit={handleSubmit}>
           <div className="mb-3 font-semibold w-full">
+            {error === 'invalid' && (
+              <p className="font-semibold text-center text-red-600">
+                이메일 또는 비밀번호를 확인해주세요.
+              </p>
+            )}
             <Input
               className="bg-white rounded-xl"
+              isInvalid={error === 'email' || error === 'invalid'}
+              errorMessage={
+                error === 'email' ? '이메일 형식이 올바르지 않습니다.' : ''
+              }
               variant="bordered"
-              type="email"
+              type="text"
               name="email"
               label="이메일"
               labelPlacement="outside"
@@ -58,6 +103,10 @@ const Page = () => {
           <div className="mb-5 font-semibold w-full">
             <Input
               variant="bordered"
+              isInvalid={error === 'password' || error === 'invalid'}
+              errorMessage={
+                error === 'password' ? '비밀번호는 6자 이상이어야 합니다.' : ''
+              }
               label="비밀번호"
               labelPlacement="outside"
               placeholder="비밀번호를 입력해주세요."

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -49,6 +49,15 @@ const Page = () => {
       });
   };
 
+  const getErrorMessage = () => {
+    switch (error) {
+      case 'email':
+        return '이메일 형식이 올바르지 않습니다.';
+      case 'password':
+        return '비밀번호는 6자 이상이어야 합니다.';
+    }
+  };
+
   if (error === 'unknown') {
     return (
       <div className="w-2/5 mx-auto flex flex-col bg-yellow-100 p-4 mt-32 rounded-lg">
@@ -87,9 +96,7 @@ const Page = () => {
             <Input
               className="bg-white rounded-xl"
               isInvalid={error === 'email' || error === 'invalid'}
-              errorMessage={
-                error === 'email' ? '이메일 형식이 올바르지 않습니다.' : ''
-              }
+              errorMessage={getErrorMessage()}
               variant="bordered"
               type="text"
               name="email"
@@ -104,9 +111,7 @@ const Page = () => {
             <Input
               variant="bordered"
               isInvalid={error === 'password' || error === 'invalid'}
-              errorMessage={
-                error === 'password' ? '비밀번호는 6자 이상이어야 합니다.' : ''
-              }
+              errorMessage={getErrorMessage()}
               label="비밀번호"
               labelPlacement="outside"
               placeholder="비밀번호를 입력해주세요."

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { signInWithEmailAndPassword } from 'firebase/auth';
 
 import auth from '@/app/auth';
+import UnknownError from '@/components/UnknownError';
 import { validateEmail, validatePassword } from '@/utils/validate';
 
 const Page = () => {
@@ -13,8 +14,8 @@ const Page = () => {
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<
-    'invalid' | 'unknown' | 'password' | 'email' | ''
-  >('');
+    'invalid' | 'unknown' | 'password' | 'email' | null
+  >(null);
   const router = useRouter();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -59,25 +60,7 @@ const Page = () => {
   };
 
   if (error === 'unknown') {
-    return (
-      <div className="w-2/5 mx-auto flex flex-col bg-yellow-100 p-4 mt-32 rounded-lg">
-        <h1 className="mx-auto font-bold text-red-600 text-xl">오류</h1>
-        <p className="mx-auto my-5 text-center">
-          알 수 없는 오류가 발생했습니다.
-          <br /> 다시 시도해 주세요.
-        </p>
-        <Button
-          type="button"
-          color="danger"
-          onClick={() => {
-            setError('');
-          }}
-          className="font-semibold w-3/5 mx-auto"
-        >
-          로그인 페이지로 이동하기
-        </Button>
-      </div>
-    );
+    return <UnknownError onClick={() => setError(null)} useAt={'login'} />;
   }
 
   return (

--- a/src/app/signUp/layout.tsx
+++ b/src/app/signUp/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+import Header from '@/components/Header';
+
+const SignUp = ({ children }: { children: ReactNode }) => {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+};
+
+export default SignUp;

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -18,7 +18,7 @@ const Page = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<
     'emailInUse' | 'invalidEmail' | 'weakPassword' | 'unknown' | null
-  >('unknown');
+  >(null);
   const router = useRouter();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -8,7 +8,7 @@ import { Input, Button, Spinner } from '@nextui-org/react';
 
 import auth from '@/app/auth';
 import db from '@/app/db';
-import Header from '@/components/Header';
+import UnknownError from '@/components/UnknownError';
 import { validateEmail } from '@/utils/validate';
 
 const Page = () => {
@@ -17,8 +17,8 @@ const Page = () => {
   const [nickname, setNickname] = useState('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<
-    'emailInUse' | 'invalidEmail' | 'weakPassword' | null
-  >(null);
+    'emailInUse' | 'invalidEmail' | 'weakPassword' | 'unknown' | null
+  >('unknown');
   const router = useRouter();
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -52,7 +52,7 @@ const Page = () => {
         } else if (err.message.includes(AuthErrorCodes.WEAK_PASSWORD)) {
           setError('weakPassword');
         } else {
-          // 에러 fallback 옵션 추가할 것
+          setError('unknown');
         }
       })
       .finally(() => {
@@ -71,9 +71,12 @@ const Page = () => {
     }
   };
 
+  if (error === 'unknown') {
+    return <UnknownError onClick={() => setError(null)} useAt={'signUp'} />;
+  }
+
   return (
     <>
-      <Header />
       <h1 className="w-2/4 mx-auto text-center font-bold text-2xl mb-5 mt-32">
         회원가입
       </h1>

--- a/src/app/upload/layout.tsx
+++ b/src/app/upload/layout.tsx
@@ -1,0 +1,14 @@
+import { ReactNode } from 'react';
+
+import Header from '@/components/Header';
+
+const Upload = ({ children }: { children: ReactNode }) => {
+  return (
+    <>
+      <Header />
+      {children}
+    </>
+  );
+};
+
+export default Upload;

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -12,17 +12,18 @@ import { useState, ChangeEvent, FormEvent, useContext } from 'react';
 import { addDoc, collection } from 'firebase/firestore';
 import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 
-import Header from '@/components/Header';
 import db from '../db';
 import { validateNewPlaceForm } from '@/utils/validate';
 import { AuthContext } from '../AuthContext';
 import { NewPlaceForm } from '@/types/place';
+import UnknownError from '@/components/UnknownError';
 
 const Page = () => {
   const { user } = useContext(AuthContext);
   const [newPlace, setNewPlace] = useState<Partial<NewPlaceForm>>({});
   const [files, setFiles] = useState<File[]>([]);
   const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [error, setError] = useState<'error' | null>(null);
   const router = useRouter();
 
   if (!user) {
@@ -103,15 +104,18 @@ const Page = () => {
       await addDoc(collection(db, 'places'), newPlaceData);
       router.push('/');
     } catch (e) {
-      console.error('Error adding document: ', e);
+      setError('error');
     } finally {
       setIsUploading(false);
     }
   };
 
+  if (error) {
+    return <UnknownError onClick={() => setError(null)} useAt={'upload'} />;
+  }
+
   return (
     <>
-      <Header />
       <h1 className="mt-20 text-center font-bold text-2xl mb-5">
         추천 여행지 등록하기
       </h1>

--- a/src/components/UnknownError.tsx
+++ b/src/components/UnknownError.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@nextui-org/react';
+
+type UnknownErrorProps = {
+  onClick: () => void;
+  useAt: 'login' | 'signUp' | 'upload';
+};
+
+const UnknownError = ({ onClick, useAt }: UnknownErrorProps) => {
+  const getButtonText = () => {
+    switch (useAt) {
+      case 'login':
+        return '로그인 페이지로 이동';
+      case 'signUp':
+        return '회원가입 페이지로 이동';
+      case 'upload':
+        return '업로드 페이지로 이동';
+    }
+  };
+
+  return (
+    <div className="w-2/5 mx-auto flex flex-col bg-yellow-100 p-4 mt-32 rounded-lg">
+      <h1 className="mx-auto font-bold text-red-600 text-xl">오류</h1>
+      <p className="mx-auto my-5 text-center">
+        알 수 없는 오류가 발생했습니다.
+        <br /> 다시 시도해 주세요.
+      </p>
+      <Button
+        type="button"
+        color="danger"
+        onClick={onClick}
+        className="font-semibold w-3/5 mx-auto"
+      >
+        {getButtonText()}
+      </Button>
+    </div>
+  );
+};
+
+export default UnknownError;

--- a/src/components/UnknownError.tsx
+++ b/src/components/UnknownError.tsx
@@ -17,11 +17,22 @@ const UnknownError = ({ onClick, useAt }: UnknownErrorProps) => {
     }
   };
 
+  const getErrorMessage = () => {
+    switch (useAt) {
+      case 'login':
+        return '로그인 중 오류가 발생했습니다.';
+      case 'signUp':
+        return '회원가입 중 오류가 발생했습니다.';
+      case 'upload':
+        return '업로드 중 오류가 발생했습니다.';
+    }
+  };
+
   return (
     <div className="w-2/5 mx-auto flex flex-col bg-yellow-100 p-4 mt-32 rounded-lg">
       <h1 className="mx-auto font-bold text-red-600 text-xl">오류</h1>
       <p className="mx-auto my-5 text-center">
-        알 수 없는 오류가 발생했습니다.
+        {getErrorMessage()}
         <br /> 다시 시도해 주세요.
       </p>
       <Button

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -25,3 +25,7 @@ export const validateEmail = (email: string) => {
     /^(?!\.)(?!.*\.\.)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   return emailRegex.test(email);
 };
+
+export const validatePassword = (password: string) => {
+  return password.length < 6;
+};


### PR DESCRIPTION
[관련 이슈](https://github.com/f-lab-edu/Share-The-Journey/issues/55)

## 작업 내용
- 불특정 에러가 발생했을 때 렌더링할 컴포넌트 구현
- Form에서 간단하게 걸러내지 못하는 에러의 경우 특정 에러 컴포넌트를 렌더링한다.
### 추가 작업
- 로그인, 회원가입, 장소 업로드 페이지의 Header 컴포넌트를 layout으로 추출 

## 작업 결과
### 로그인
- 기타 에러
![image](https://github.com/user-attachments/assets/36d5f7e5-5464-4ce6-a612-d8a9e16aaf41)
- 이메일 형식 입력 오류
![image](https://github.com/user-attachments/assets/dc2f2dd3-2f9b-4ef4-a527-9193133d4a67)
- 비밀번호 오류
![image](https://github.com/user-attachments/assets/42b8c571-685f-4cb2-a57a-93bb5ff03bdc)
- 이메일, 비밀번호 오입력
![image](https://github.com/user-attachments/assets/c299bdaf-fbea-49cf-99c0-29691b913eba)

### 회원가입, 장소 업로드
- 회원가입
![image](https://github.com/user-attachments/assets/95dda682-2a44-4a73-b9b4-3d638951e0b9)
- 장소 업로드
![image](https://github.com/user-attachments/assets/fe59f91e-9271-4c31-9a89-d559804f78e8)
